### PR TITLE
[FEAT] 멤버, 뱃지, 칭찬, 리뷰 관련 서비스 로직

### DIFF
--- a/src/main/kotlin/sundaystudy/kr/usedcar/config/security/oauth/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/config/security/oauth/OAuth2AuthenticationSuccessHandler.kt
@@ -15,7 +15,7 @@ class OAuth2AuthenticationSuccessHandler(
     private val jwtCookieProvider: JwtCookieProvider,
 ): SimpleUrlAuthenticationSuccessHandler() {
     @Value("\${app.auth.authorizedRedirectUri}")
-    lateinit var REDIRECT_URI: String
+    private lateinit var REDIRECT_URI: String
 
     override fun onAuthenticationSuccess(
         request: HttpServletRequest?, response: HttpServletResponse, authentication: Authentication

--- a/src/main/kotlin/sundaystudy/kr/usedcar/global/exception/EntityNotFoundException.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/global/exception/EntityNotFoundException.kt
@@ -1,0 +1,5 @@
+package sundaystudy.kr.usedcar.global.exception
+
+class EntityNotFoundException(
+    override val message: String = "엔티티 조회중 오류가 발생했습니다."
+): IllegalArgumentException(message)

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/controller/BadgeController.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/controller/BadgeController.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.badge.controller
 
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import sundaystudy.kr.usedcar.module.badge.dto.request.RepresentBadgeRequest
@@ -18,6 +19,6 @@ class BadgeController(
     }
 
     @GetMapping
-    fun getAllBadges(): ResponseEntity<List<BadgeResponse>> =
-        ResponseEntity.ok(badgeService.getAllBadges())
+    fun getAllBadges(pageable: Pageable): ResponseEntity<List<BadgeResponse>> =
+        ResponseEntity.ok(badgeService.getAllBadges(pageable))
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/entity/Badge.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/entity/Badge.kt
@@ -15,17 +15,35 @@ class Badge(
     val badgeName: String,
 
     @JoinColumn
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     var member: Member,
 ) : Auditable {
+
+    init {
+        organizeMember(this.member)
+    }
 
     @Id
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID = UUID.randomUUID()
 
-    var isRepresent: Boolean? = null
+    var isRepresent: Boolean = false
         protected set
 
     @Embedded
     override var baseTime: BaseTime = BaseTime()
+
+    fun updateToRepresent() {
+        this.member.badges.find(Badge::isRepresent)?.updateToNotRepresent()
+        this.isRepresent = true
+    }
+
+    private fun updateToNotRepresent() {
+        this.isRepresent = false
+    }
+
+    private fun organizeMember(member: Member) {
+        this.member = member
+        member.organizeBadge(this)
+    }
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/mapper/BadgeMapper.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/mapper/BadgeMapper.kt
@@ -1,0 +1,21 @@
+package sundaystudy.kr.usedcar.module.badge.mapper
+
+import org.springframework.stereotype.Component
+import sundaystudy.kr.usedcar.module.badge.dto.response.BadgeResponse
+import sundaystudy.kr.usedcar.module.badge.entity.Badge
+
+@Component
+class BadgeMapper {
+
+    fun toResponseList(badgeList: List<Badge>): List<BadgeResponse> =
+        badgeList.map(this::toResponse)
+
+    private fun toResponse(badge: Badge): BadgeResponse {
+        return BadgeResponse(
+            id = badge.id,
+            memberId = badge.member.id,
+            badgeName = badge.badgeName,
+            isRepresent = badge.isRepresent
+        )
+    }
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/repository/BadgeRepository.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/repository/BadgeRepository.kt
@@ -2,6 +2,6 @@ package sundaystudy.kr.usedcar.module.badge.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import sundaystudy.kr.usedcar.module.badge.entity.Badge
-import java.util.UUID
+import java.util.*
 
 interface BadgeRepository : JpaRepository<Badge, UUID>

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/service/BadgeService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/service/BadgeService.kt
@@ -1,19 +1,32 @@
 package sundaystudy.kr.usedcar.module.badge.service
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import sundaystudy.kr.usedcar.global.exception.EntityNotFoundException
 import sundaystudy.kr.usedcar.module.badge.dto.request.RepresentBadgeRequest
 import sundaystudy.kr.usedcar.module.badge.dto.response.BadgeResponse
+import sundaystudy.kr.usedcar.module.badge.entity.Badge
+import sundaystudy.kr.usedcar.module.badge.mapper.BadgeMapper
 import sundaystudy.kr.usedcar.module.badge.repository.BadgeRepository
+import java.util.*
 
 @Service
 class BadgeService(
     private val badgeRepository: BadgeRepository,
+    private val badgeMapper: BadgeMapper,
 ) {
+    @Transactional
     fun selectRepresentBadge(representBadgeRequest: RepresentBadgeRequest) {
-        TODO("Not yet implemented")
+        val badge = getEntity(representBadgeRequest.id)
+        badge.updateToRepresent()
     }
 
-    fun getAllBadges(): List<BadgeResponse> {
-        TODO("Not yet implemented")
-    }
+    fun getAllBadges(pageable: Pageable): List<BadgeResponse> =
+        badgeMapper.toResponseList(badgeRepository.findAll(pageable).content)
+
+
+    private fun getEntity(id: UUID): Badge =
+        badgeRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/service/BadgeService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/service/BadgeService.kt
@@ -28,5 +28,5 @@ class BadgeService(
 
 
     private fun getEntity(id: UUID): Badge =
-        badgeRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
+        badgeRepository.findByIdOrNull(id) ?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/dto/response/MemberDetailsResponse.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/dto/response/MemberDetailsResponse.kt
@@ -4,7 +4,7 @@ import java.util.*
 
 data class MemberDetailsResponse(
     var id: UUID,
-    var nickname: String,
+    var nickname: String?,
     var mannerTemperature: Double,
     var rateOfReDealing: Double,
     var responseRate: Double,

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/entity/Member.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/entity/Member.kt
@@ -7,6 +7,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import sundaystudy.kr.usedcar.global.audit.AuditListener
 import sundaystudy.kr.usedcar.global.audit.Auditable
 import sundaystudy.kr.usedcar.global.audit.BaseTime
+import sundaystudy.kr.usedcar.module.badge.entity.Badge
 import java.util.*
 
 @Entity
@@ -39,6 +40,10 @@ class Member(
     var role: Role = Role.ROLE_USER
         protected set
 
+    @OneToMany(mappedBy = "member")
+    var badges: MutableList<Badge> = mutableListOf()
+        protected set
+
     @Embedded
     override var baseTime: BaseTime = BaseTime()
 
@@ -47,6 +52,10 @@ class Member(
 
     fun updateRefreshToken(refreshToken: String) {
         this.refreshToken = refreshToken
+    }
+
+    fun organizeBadge(badge: Badge) {
+        this.badges.add(badge)
     }
 
     // TODO Double 필드 3개에 대한 업데이트 로직 함수 작성

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/mapper/MemberMapper.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/mapper/MemberMapper.kt
@@ -13,7 +13,9 @@ class MemberMapper {
         Member(
             oAuth2Details = OAuth2Details(
                 clientId = oAuth2Request.clientId,
-                authProvider =  oAuth2Request.authProvider))
+                authProvider = oAuth2Request.authProvider
+            )
+        )
 
     fun toDetailsResponse(member: Member): MemberDetailsResponse =
         MemberDetailsResponse(

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/mapper/MemberMapper.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/mapper/MemberMapper.kt
@@ -2,6 +2,7 @@ package sundaystudy.kr.usedcar.module.member.mapper
 
 import org.springframework.stereotype.Component
 import sundaystudy.kr.usedcar.config.security.oauth.OAuth2Request
+import sundaystudy.kr.usedcar.module.member.dto.response.MemberDetailsResponse
 import sundaystudy.kr.usedcar.module.member.entity.Member
 import sundaystudy.kr.usedcar.module.member.entity.OAuth2Details
 
@@ -9,5 +10,17 @@ import sundaystudy.kr.usedcar.module.member.entity.OAuth2Details
 class MemberMapper {
 
     fun toEntity(oAuth2Request: OAuth2Request): Member =
-        Member(oAuth2Details = OAuth2Details(oAuth2Request.clientId, oAuth2Request.authProvider))
+        Member(
+            oAuth2Details = OAuth2Details(
+                clientId = oAuth2Request.clientId,
+                authProvider =  oAuth2Request.authProvider))
+
+    fun toDetailsResponse(member: Member): MemberDetailsResponse =
+        MemberDetailsResponse(
+            id = member.id,
+            nickname = member.nickname,
+            mannerTemperature = member.mannerTemperature,
+            rateOfReDealing = member.rateOfReDealing,
+            responseRate = member.responseRate
+        )
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/repository/MemberRepository.kt
@@ -13,6 +13,7 @@ interface MemberRepository : JpaRepository<Member, UUID> {
     @Query("UPDATE Member m SET m.refreshToken = :refreshToken WHERE m.id = :id")
     fun updateRefreshToken(id: UUID, refreshToken: String)
     fun findByoAuth2DetailsClientId(clientId: String): Member?
+
     @Query("SELECT m.refreshToken FROM Member m WHERE m.id = :id")
     fun findRefreshTokenById(id: UUID): String
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/service/MemberService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/service/MemberService.kt
@@ -1,23 +1,31 @@
 package sundaystudy.kr.usedcar.module.member.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import sundaystudy.kr.usedcar.config.security.oauth.OAuth2Request
+import sundaystudy.kr.usedcar.global.exception.EntityNotFoundException
 import sundaystudy.kr.usedcar.module.member.dto.response.MemberDetailsResponse
 import sundaystudy.kr.usedcar.module.member.entity.Member
 import sundaystudy.kr.usedcar.module.member.mapper.MemberMapper
 import sundaystudy.kr.usedcar.module.member.repository.MemberRepository
+import java.util.*
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val memberMapper: MemberMapper
+    private val memberMapper: MemberMapper,
+    private val authService: AuthService,
 ) {
     fun getMemberDetails(): MemberDetailsResponse {
-        TODO("Not yet implemented")
+        val loginUser = authService.getLoginUser()
+        return memberMapper.toDetailsResponse(loginUser)
     }
 
     fun saveIfNone(oAuth2Request: OAuth2Request): Member {
         return memberRepository.findByoAuth2DetailsClientId(oAuth2Request.clientId)
             ?: memberRepository.save(memberMapper.toEntity(oAuth2Request))
     }
+
+    fun getEntity(id: UUID) =
+        memberRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/service/MemberService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/service/MemberService.kt
@@ -27,5 +27,5 @@ class MemberService(
     }
 
     fun getEntity(id: UUID) =
-        memberRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
+        memberRepository.findByIdOrNull(id) ?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseController.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseController.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.praise.controller
 
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -20,11 +21,11 @@ class PraiseController(
         ResponseEntity.status(HttpStatus.CREATED).body(praiseService.savePraise(praiseRequest))
 
     @GetMapping
-    fun getAllPraises(): ResponseEntity<List<PraiseResponse>> =
-        ResponseEntity.ok(praiseService.getAllPraises())
+    fun getAllPraises(pageable: Pageable): ResponseEntity<List<PraiseResponse>> =
+        ResponseEntity.ok(praiseService.getAllPraises(pageable))
 
     @GetMapping("members/{memberId}")
-    fun getPraiseByMemberId(@PathVariable memberId: UUID): ResponseEntity<PraiseResponse> =
+    fun getPraiseByMemberId(@PathVariable memberId: UUID): ResponseEntity<List<PraiseResponse>> =
         ResponseEntity.ok(praiseService.getPraiseByMemberId(memberId))
 
     @GetMapping("{id}")

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/request/PraiseRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/request/PraiseRequest.kt
@@ -3,7 +3,7 @@ package sundaystudy.kr.usedcar.module.praise.dto.request
 import java.util.*
 
 data class PraiseRequest(
-    var praiserId: UUID,
+    var content: String,
     var memberId: UUID,
     var praiseType: String,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/entity/Praise.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/entity/Praise.kt
@@ -20,11 +20,11 @@ class Praise(
     val content: String,
 
     @JoinColumn
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     val member: Member,
 
     @JoinColumn
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     val praiser: Member,
 ) : Auditable {
     @Id

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/mapper/PraiseMapper.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/mapper/PraiseMapper.kt
@@ -1,0 +1,37 @@
+package sundaystudy.kr.usedcar.module.praise.mapper
+
+import org.springframework.stereotype.Component
+import sundaystudy.kr.usedcar.module.member.entity.Member
+import sundaystudy.kr.usedcar.module.praise.dto.request.PraiseRequest
+import sundaystudy.kr.usedcar.module.praise.dto.response.PraiseDetailsResponse
+import sundaystudy.kr.usedcar.module.praise.dto.response.PraiseResponse
+import sundaystudy.kr.usedcar.module.praise.entity.Praise
+
+@Component
+class PraiseMapper {
+    fun toEntity(praiseRequest: PraiseRequest, member: Member, praiser: Member): Praise =
+        Praise(
+            praiseType = praiseRequest.praiseType,
+            content = praiseRequest.content,
+            member = member,
+            praiser = praiser
+        )
+
+    fun toResponseList(praiseList: List<Praise>): List<PraiseResponse> =
+        praiseList.map(this::toResponse)
+
+    private fun toResponse(praise: Praise): PraiseResponse =
+        PraiseResponse(
+            id = praise.id,
+            memberId = praise.member.id,
+            praiseType = praise.praiseType,
+            amount = praise.amount
+        )
+
+    fun toDetailsResponse(praise: Praise): PraiseDetailsResponse =
+        PraiseDetailsResponse(
+            id = praise.id,
+            praiseType = praise.praiseType,
+            content = praise.content
+        )
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/repository/PraiseRepository.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/repository/PraiseRepository.kt
@@ -1,7 +1,10 @@
 package sundaystudy.kr.usedcar.module.praise.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import sundaystudy.kr.usedcar.module.member.entity.Member
 import sundaystudy.kr.usedcar.module.praise.entity.Praise
-import java.util.UUID
+import java.util.*
 
-interface PraiseRepository : JpaRepository<Praise, UUID>
+interface PraiseRepository : JpaRepository<Praise, UUID> {
+    fun findByMember(member: Member): List<Praise>
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/service/PraiseService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/service/PraiseService.kt
@@ -1,30 +1,46 @@
 package sundaystudy.kr.usedcar.module.praise.service
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import sundaystudy.kr.usedcar.global.dto.IdResponse
+import sundaystudy.kr.usedcar.global.exception.EntityNotFoundException
+import sundaystudy.kr.usedcar.module.member.service.AuthService
+import sundaystudy.kr.usedcar.module.member.service.MemberService
 import sundaystudy.kr.usedcar.module.praise.dto.request.PraiseRequest
 import sundaystudy.kr.usedcar.module.praise.dto.response.PraiseDetailsResponse
 import sundaystudy.kr.usedcar.module.praise.dto.response.PraiseResponse
+import sundaystudy.kr.usedcar.module.praise.entity.Praise
+import sundaystudy.kr.usedcar.module.praise.mapper.PraiseMapper
 import sundaystudy.kr.usedcar.module.praise.repository.PraiseRepository
 import java.util.*
 
 @Service
 class PraiseService(
     private val praiseRepository: PraiseRepository,
+    private val praiseMapper: PraiseMapper,
+    private val authService: AuthService,
+    private val memberService: MemberService,
 ) {
     fun savePraise(praiseRequest: PraiseRequest): IdResponse {
-        TODO("Not yet implemented")
+        val praiser = authService.getLoginUser()
+        val praiseReciever = memberService.getEntity(praiseRequest.memberId)
+        val praise = praiseRepository.save(praiseMapper.toEntity(praiseRequest, praiseReciever, praiser))
+        return IdResponse(praise.id)
     }
 
-    fun getAllPraises(): List<PraiseResponse> {
-        TODO("Not yet implemented")
+    fun getAllPraises(pageable: Pageable): List<PraiseResponse> =
+        praiseMapper.toResponseList(praiseRepository.findAll(pageable).content)
+
+
+    fun getPraiseByMemberId(memberId: UUID): List<PraiseResponse> {
+        val praiseReciever = memberService.getEntity(memberId)
+        return praiseMapper.toResponseList(praiseRepository.findByMember(praiseReciever))
     }
 
-    fun getPraiseByMemberId(memberId: UUID): PraiseResponse {
-        TODO("Not yet implemented")
-    }
+    fun getPraiseDetails(id: UUID): PraiseDetailsResponse =
+        praiseMapper.toDetailsResponse(getEntity(id))
 
-    fun getPraiseDetails(id: UUID): PraiseDetailsResponse {
-        TODO("Not yet implemented")
-    }
+    private fun getEntity(id: UUID): Praise =
+        praiseRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/service/PraiseService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/service/PraiseService.kt
@@ -42,5 +42,5 @@ class PraiseService(
         praiseMapper.toDetailsResponse(getEntity(id))
 
     private fun getEntity(id: UUID): Praise =
-        praiseRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
+        praiseRepository.findByIdOrNull(id) ?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/controller/ReviewController.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/controller/ReviewController.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.review.controller
 
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -19,8 +20,8 @@ class ReviewController(
         ResponseEntity.status(HttpStatus.CREATED).body(reviewService.saveReview(reviewRequest))
 
     @GetMapping
-    fun getAllReview(): ResponseEntity<List<ReviewResponse>> =
-        ResponseEntity.ok(reviewService.getAllReviews())
+    fun getAllReview(pageable: Pageable): ResponseEntity<List<ReviewResponse>> =
+        ResponseEntity.ok(reviewService.getAllReviews(pageable))
 
     @GetMapping("{id}")
     fun getReview(@PathVariable id: UUID): ResponseEntity<ReviewResponse> =

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/dto/request/ReviewRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/dto/request/ReviewRequest.kt
@@ -5,5 +5,4 @@ import java.util.*
 data class ReviewRequest(
     var content: String,
     var memberId: UUID,
-    var reviewerId: UUID,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/mapper/ReviewMapper.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/mapper/ReviewMapper.kt
@@ -1,0 +1,28 @@
+package sundaystudy.kr.usedcar.module.review.mapper
+
+import org.springframework.stereotype.Component
+import sundaystudy.kr.usedcar.module.member.entity.Member
+import sundaystudy.kr.usedcar.module.review.dto.request.ReviewRequest
+import sundaystudy.kr.usedcar.module.review.dto.response.ReviewResponse
+import sundaystudy.kr.usedcar.module.review.entity.Review
+
+@Component
+class ReviewMapper {
+
+    fun toEntity(reviewRequest: ReviewRequest, member: Member, reviewer: Member): Review =
+        Review(
+            content = reviewRequest.content,
+            member = member,
+            reviewer = reviewer
+        )
+
+    fun toResponseList(reviewList: List<Review>): List<ReviewResponse> =
+        reviewList.map(this::toResponse)
+
+    fun toResponse(review: Review): ReviewResponse =
+        ReviewResponse(
+            id = review.id,
+            content = review.content,
+            memberId = review.member.id
+        )
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/repository/ReviewRepository.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/repository/ReviewRepository.kt
@@ -2,6 +2,8 @@ package sundaystudy.kr.usedcar.module.review.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import sundaystudy.kr.usedcar.module.review.entity.Review
-import java.util.UUID
+import java.util.*
 
-interface ReviewRepository : JpaRepository<Review, UUID>
+interface ReviewRepository : JpaRepository<Review, UUID> {
+    fun findAllByMemberId(memberId: UUID): List<Review>
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/service/ReviewService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/service/ReviewService.kt
@@ -37,5 +37,5 @@ class ReviewService(
         reviewMapper.toResponseList(reviewRepository.findAllByMemberId(memberId))
 
     private fun getEntity(id: UUID) =
-        reviewRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
+        reviewRepository.findByIdOrNull(id) ?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/service/ReviewService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/service/ReviewService.kt
@@ -1,29 +1,41 @@
 package sundaystudy.kr.usedcar.module.review.service
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import sundaystudy.kr.usedcar.global.dto.IdResponse
+import sundaystudy.kr.usedcar.global.exception.EntityNotFoundException
+import sundaystudy.kr.usedcar.module.member.service.AuthService
+import sundaystudy.kr.usedcar.module.member.service.MemberService
 import sundaystudy.kr.usedcar.module.review.dto.request.ReviewRequest
 import sundaystudy.kr.usedcar.module.review.dto.response.ReviewResponse
+import sundaystudy.kr.usedcar.module.review.mapper.ReviewMapper
 import sundaystudy.kr.usedcar.module.review.repository.ReviewRepository
 import java.util.*
 
 @Service
 class ReviewService(
     private val reviewRepository: ReviewRepository,
+    private val reviewMapper: ReviewMapper,
+    private val memberService: MemberService,
+    private val authService: AuthService,
 ) {
     fun saveReview(reviewRequest: ReviewRequest): IdResponse {
-        TODO("Not yet implemented")
+        val member = memberService.getEntity(reviewRequest.memberId)
+        val reviewer = authService.getLoginUser()
+        val review = reviewRepository.save(reviewMapper.toEntity(reviewRequest, member, reviewer))
+        return IdResponse(review.id)
     }
 
-    fun getAllReviews(): List<ReviewResponse> {
-        TODO("Not yet implemented")
-    }
+    fun getAllReviews(pageable: Pageable): List<ReviewResponse> =
+        reviewMapper.toResponseList(reviewRepository.findAll(pageable).content)
 
-    fun getReview(id: UUID): ReviewResponse {
-        TODO("Not yet implemented")
-    }
+    fun getReview(id: UUID): ReviewResponse =
+        reviewMapper.toResponse(getEntity(id))
 
-    fun getAllReviewsByMemberId(memberId: UUID): List<ReviewResponse> {
-        TODO("Not yet implemented")
-    }
+    fun getAllReviewsByMemberId(memberId: UUID): List<ReviewResponse> =
+        reviewMapper.toResponseList(reviewRepository.findAllByMemberId(memberId))
+
+    private fun getEntity(id: UUID) =
+        reviewRepository.findByIdOrNull(id)?: throw EntityNotFoundException()
 }

--- a/src/test/kotlin/sundaystudy/kr/usedcar/module/badge/controller/BadgeControllerTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/module/badge/controller/BadgeControllerTest.kt
@@ -6,6 +6,7 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.`when`
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.domain.Pageable
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
@@ -56,7 +57,7 @@ class BadgeControllerTest: RestDocsTest() {
         val expected = listOf(
             BadgeResponse(UUID.randomUUID(), UUID.randomUUID(), "거래왕", true),
             BadgeResponse(UUID.randomUUID(), UUID.randomUUID(), "친절왕", true))
-        `when`(badgeService.getAllBadges()).thenReturn(expected)
+        `when`(badgeService.getAllBadges(any(Pageable::class.java))).thenReturn(expected)
 
         //when
         val perform = mockMvc.perform(

--- a/src/test/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseControllerTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseControllerTest.kt
@@ -33,7 +33,7 @@ class PraiseControllerTest: RestDocsTest() {
         //when
         val perform = mockMvc.perform(
             post("/praises")
-                .content(toRequestBody(PraiseRequest(UUID.randomUUID(), UUID.randomUUID(), "친절해요")))
+                .content(toRequestBody(PraiseRequest("칭찬합니다~~", UUID.randomUUID(), "친절해요")))
                 .header("Authorization", "Bearer 12asdf21435.asdfgafdsg231f.432t4243cf")
                 .contentType(MediaType.APPLICATION_JSON))
 


### PR DESCRIPTION
## 멤버, 뱃지, 칭찬, 리뷰 도메인
- 서비스 로직 추가
- Mapper 추가

### 작성 파일이 많아 rest docs를 위한 테스트 코드는 작성안한 채로 먼저 pr 날립니다.

## 질문 사항
- response dto 에 nullable (?타입) 이 들어가도 되는지 -> 코틀린 이해도 이슈..
    - MemberDetailsResponse 에 해당 내용 있습니다

## 참고 사항
- fetch join과 같은 경우는 아직 고려하지 않고 개발했습니다. (추후 필요시 추가할 예정)
- EntityNotFoundException이 많이 쓰일 것 같아서 global.exception 밑에 만들어뒀습니다.
    - controller advice는 아직입니다.
- 전체 조회의 경우 모두 Pageable 쓰는 방향으로 수정했습니다.