### PR TITLE
[FEAT] Member관련 도메인 ulid, validation, controller-advice

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
     implementation("org.mapstruct:mapstruct:1.5.5.Final")
+    implementation("com.github.f4b6a3:ulid-creator:5.2.2")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     api("org.flywaydb:flyway-core:9.16.0")
 
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/sundaystudy/kr/usedcar/global/advice/ErrorAdvice.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/global/advice/ErrorAdvice.kt
@@ -1,0 +1,20 @@
+package sundaystudy.kr.usedcar.global.advice
+
+import jakarta.validation.ValidationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import sundaystudy.kr.usedcar.global.exception.EntityNotFoundException
+
+@RestControllerAdvice
+class ErrorAdvice {
+
+    @ExceptionHandler(EntityNotFoundException::class)
+    fun jwtProcessingException(e: EntityNotFoundException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse(e.message))
+
+    @ExceptionHandler(ValidationException::class)
+    fun validationException(e: ValidationException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse(e.message))
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/global/advice/ErrorResponse.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/global/advice/ErrorResponse.kt
@@ -1,0 +1,5 @@
+package sundaystudy.kr.usedcar.global.advice
+
+data class ErrorResponse(
+    var message: String?
+)

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/controller/BadgeController.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/controller/BadgeController.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.badge.controller
 
+import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -13,7 +14,7 @@ class BadgeController(
     private val badgeService: BadgeService,
 ) {
     @PostMapping
-    fun selectRepresentBadge(@RequestBody representBadgeRequest: RepresentBadgeRequest): ResponseEntity<Any> {
+    fun selectRepresentBadge(@RequestBody @Valid representBadgeRequest: RepresentBadgeRequest): ResponseEntity<Unit> {
         badgeService.selectRepresentBadge(representBadgeRequest)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/dto/request/RepresentBadgeRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/dto/request/RepresentBadgeRequest.kt
@@ -1,7 +1,9 @@
 package sundaystudy.kr.usedcar.module.badge.dto.request
 
+import jakarta.validation.constraints.NotNull
 import java.util.*
 
 data class RepresentBadgeRequest(
+    @field:NotNull
     var id: UUID
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/entity/Badge.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/entity/Badge.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.badge.entity
 
+import com.github.f4b6a3.ulid.UlidCreator
 import jakarta.persistence.*
 import org.hibernate.annotations.Where
 import sundaystudy.kr.usedcar.global.audit.AuditListener
@@ -25,7 +26,7 @@ class Badge(
 
     @Id
     @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID()
+    val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
 
     var isRepresent: Boolean = false
         protected set

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/controller/advice/AuthControllerAdvice.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/controller/advice/AuthControllerAdvice.kt
@@ -1,0 +1,16 @@
+package sundaystudy.kr.usedcar.module.member.controller.advice
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import sundaystudy.kr.usedcar.global.advice.ErrorResponse
+import sundaystudy.kr.usedcar.module.member.exception.JwtProcessingException
+
+@RestControllerAdvice
+class AuthControllerAdvice {
+
+    @ExceptionHandler(JwtProcessingException::class)
+    fun jwtProcessingException(e: JwtProcessingException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse(e.message))
+}

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/entity/Member.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/entity/Member.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.member.entity
 
+import com.github.f4b6a3.ulid.UlidCreator
 import jakarta.persistence.*
 import org.hibernate.annotations.Where
 import org.springframework.security.core.GrantedAuthority
@@ -19,7 +20,7 @@ class Member(
 ) : Auditable {
     @Id
     @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID()
+    val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
 
     var nickname: String? = null
         protected set
@@ -57,6 +58,4 @@ class Member(
     fun organizeBadge(badge: Badge) {
         this.badges.add(badge)
     }
-
-    // TODO Double 필드 3개에 대한 업데이트 로직 함수 작성
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/member/service/AuthService.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/member/service/AuthService.kt
@@ -1,6 +1,7 @@
 package sundaystudy.kr.usedcar.module.member.service
 
 import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.util.StringUtils
@@ -69,6 +70,5 @@ class AuthService(
     }
 
     fun getLoginUser(): Member =
-        memberRepository.findById(getLoginUserId())
-            .orElseThrow { EntityNotFoundException() }
+        memberRepository.findByIdOrNull(getLoginUserId()) ?: throw EntityNotFoundException()
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseController.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseController.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.praise.controller
 
+import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,7 +19,7 @@ class PraiseController(
     private val praiseService: PraiseService,
 ) {
     @PostMapping
-    fun savePraise(@RequestBody praiseRequest: PraiseRequest): ResponseEntity<IdResponse> =
+    fun savePraise(@RequestBody @Valid praiseRequest: PraiseRequest): ResponseEntity<IdResponse> =
         ResponseEntity.status(HttpStatus.CREATED).body(praiseService.savePraise(praiseRequest))
 
     @GetMapping
@@ -34,13 +35,13 @@ class PraiseController(
         ResponseEntity.ok(praiseService.getPraiseDetails(id))
 
     @PutMapping
-    fun updatePraise(@RequestBody praiseUpdateRequest: PraiseUpdateRequest): ResponseEntity<Any> {
+    fun updatePraise(@RequestBody @Valid praiseUpdateRequest: PraiseUpdateRequest): ResponseEntity<Unit> {
         praiseService.updatePraise(praiseUpdateRequest)
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("{id}")
-    fun deletePraise(@PathVariable id: UUID): ResponseEntity<Any> {
+    fun deletePraise(@PathVariable id: UUID): ResponseEntity<Unit> {
         praiseService.deletePraise(id)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/request/PraiseRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/request/PraiseRequest.kt
@@ -1,9 +1,12 @@
 package sundaystudy.kr.usedcar.module.praise.dto.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.util.*
 
 data class PraiseRequest(
-    var content: String,
+    @field:NotNull
     var memberId: UUID,
+    @field:NotBlank
     var praiseType: String,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/request/PraiseUpdateRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/request/PraiseUpdateRequest.kt
@@ -1,9 +1,12 @@
 package sundaystudy.kr.usedcar.module.praise.dto.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.util.*
 
 data class PraiseUpdateRequest(
+    @field:NotNull
     var id: UUID,
-    var content: String,
+    @field:NotBlank
     var praiseType: String,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/response/PraiseDetailsResponse.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/dto/response/PraiseDetailsResponse.kt
@@ -5,5 +5,4 @@ import java.util.*
 data class PraiseDetailsResponse(
     var id: UUID,
     var praiseType: String,
-    var content: String,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/entity/Praise.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/entity/Praise.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.praise.entity
 
+import com.github.f4b6a3.ulid.UlidCreator
 import jakarta.persistence.*
 import org.hibernate.annotations.Where
 import sundaystudy.kr.usedcar.global.audit.AuditListener
@@ -16,9 +17,6 @@ class Praise(
     @Column(nullable = false)
     var praiseType: String,
 
-    @Lob
-    var content: String,
-
     @JoinColumn
     @ManyToOne(fetch = FetchType.LAZY)
     var member: Member,
@@ -29,7 +27,7 @@ class Praise(
 ) : Auditable {
     @Id
     @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID()
+    val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
 
     var amount: Int = 1
         protected set
@@ -41,8 +39,7 @@ class Praise(
     @Embedded
     override var baseTime: BaseTime = BaseTime()
 
-    fun update(content: String, praiseType: String) {
-        this.content = content
+    fun update(praiseType: String) {
         this.praiseType = praiseType
     }
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/mapper/PraiseMapper.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/mapper/PraiseMapper.kt
@@ -12,7 +12,6 @@ class PraiseMapper {
     fun toEntity(praiseRequest: PraiseRequest, member: Member, praiser: Member): Praise =
         Praise(
             praiseType = praiseRequest.praiseType,
-            content = praiseRequest.content,
             member = member,
             praiser = praiser
         )
@@ -31,7 +30,6 @@ class PraiseMapper {
     fun toDetailsResponse(praise: Praise): PraiseDetailsResponse =
         PraiseDetailsResponse(
             id = praise.id,
-            praiseType = praise.praiseType,
-            content = praise.content
+            praiseType = praise.praiseType
         )
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/repository/PraiseRepository.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/praise/repository/PraiseRepository.kt
@@ -1,10 +1,14 @@
 package sundaystudy.kr.usedcar.module.praise.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import sundaystudy.kr.usedcar.module.member.entity.Member
 import sundaystudy.kr.usedcar.module.praise.entity.Praise
 import java.util.*
 
 interface PraiseRepository : JpaRepository<Praise, UUID> {
     fun findByMember(member: Member): List<Praise>
+
+    @Query("SELECT p FROM Praise p WHERE p.member = :member AND p.praiser = :praiser")
+    fun findByMemberAndPraiser(member: Member, praiser: Member): Praise?
 }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/controller/ReviewController.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/controller/ReviewController.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.review.controller
 
+import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -17,7 +18,7 @@ class ReviewController(
     private val reviewService: ReviewService,
 ) {
     @PostMapping
-    fun saveReview(@RequestBody reviewRequest: ReviewRequest): ResponseEntity<IdResponse> =
+    fun saveReview(@RequestBody @Valid reviewRequest: ReviewRequest): ResponseEntity<IdResponse> =
         ResponseEntity.status(HttpStatus.CREATED).body(reviewService.saveReview(reviewRequest))
 
     @GetMapping
@@ -33,13 +34,13 @@ class ReviewController(
         ResponseEntity.ok(reviewService.getAllReviewsByMemberId(memberId))
 
     @PutMapping
-    fun updateReview(@RequestBody reviewUpdateRequest: ReviewUpdateRequest): ResponseEntity<Any> {
+    fun updateReview(@RequestBody @Valid reviewUpdateRequest: ReviewUpdateRequest): ResponseEntity<Unit> {
         reviewService.updateReview(reviewUpdateRequest)
         return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("{id}")
-    fun deleteReview(@PathVariable id: UUID): ResponseEntity<Any> {
+    fun deleteReview(@PathVariable id: UUID): ResponseEntity<Unit> {
         reviewService.deleteReview(id)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/dto/request/ReviewRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/dto/request/ReviewRequest.kt
@@ -1,8 +1,12 @@
 package sundaystudy.kr.usedcar.module.review.dto.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.util.*
 
 data class ReviewRequest(
+    @field:NotBlank
     var content: String,
+    @field:NotNull
     var memberId: UUID,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/dto/request/ReviewUpdateRequest.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/dto/request/ReviewUpdateRequest.kt
@@ -1,8 +1,12 @@
 package sundaystudy.kr.usedcar.module.review.dto.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.util.*
 
 data class ReviewUpdateRequest (
+    @field:NotNull
     var id: UUID,
+    @field:NotBlank
     var content: String,
 )

--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/review/entity/Review.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/review/entity/Review.kt
@@ -1,5 +1,6 @@
 package sundaystudy.kr.usedcar.module.review.entity
 
+import com.github.f4b6a3.ulid.UlidCreator
 import jakarta.persistence.*
 import org.hibernate.annotations.Where
 import sundaystudy.kr.usedcar.global.audit.AuditListener
@@ -27,7 +28,7 @@ class Review(
 
     @Id
     @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID()
+    val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
 
     @Embedded
     override var baseTime: BaseTime = BaseTime()


### PR DESCRIPTION
- Member, Badge, Praise, Review 도메인에 추가한 사항
    - ulid
    - dto validation
    - controller advice

- global에 controller advice 및 ErrorResponse dto 추가
- Praise 저장 로직 수정
- ResponeEntity Any -> ResponseEntity Unit 으로 수정