### PR TITLE
[TEST] service 및 repository 테스트 설정과 Badge 테스트

### DIFF
--- a/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/entity/Badge.kt
+++ b/src/main/kotlin/sundaystudy/kr/usedcar/module/badge/entity/Badge.kt
@@ -15,7 +15,7 @@ import java.util.*
 class Badge(
     val badgeName: String,
 
-    @JoinColumn
+    @JoinColumn(columnDefinition = "BINARY(16)")
     @ManyToOne(fetch = FetchType.LAZY)
     var member: Member,
 ) : Auditable {
@@ -44,7 +44,6 @@ class Badge(
     }
 
     private fun organizeMember(member: Member) {
-        this.member = member
         member.organizeBadge(this)
     }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,10 +12,17 @@ spring:
     hibernate:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        auto_quote_keyword: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        storage_engine: innodb
+        format_sql: true
+    generate-ddl: true
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:usedcar
+    url: jdbc:h2:mem:usedcar;MODE=MySQL;
     username: sa
     password:
 

--- a/src/test/kotlin/sundaystudy/kr/usedcar/module/badge/repository/BadgeRepositoryTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/module/badge/repository/BadgeRepositoryTest.kt
@@ -1,0 +1,58 @@
+package sundaystudy.kr.usedcar.module.badge.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import sundaystudy.kr.usedcar.module.badge.entity.Badge
+import sundaystudy.kr.usedcar.module.member.entity.AuthProvider
+import sundaystudy.kr.usedcar.module.member.entity.Member
+import sundaystudy.kr.usedcar.module.member.entity.OAuth2Details
+import sundaystudy.kr.usedcar.module.member.repository.MemberRepository
+import sundaystudy.kr.usedcar.support.infra.EnableJpaTest
+
+@EnableJpaTest
+@DisplayName("Badge 레포지토리에")
+class BadgeRepositoryTest {
+
+    @Autowired
+    private lateinit var badgeRepository: BadgeRepository
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Test
+    @DisplayName("id로 조회시 저장한 데이터가 조회된다")
+    fun findByIdOrNull() {
+        // given
+        val member = memberRepository.save(Member(OAuth2Details("123", AuthProvider.GOOGLE)))
+        val expected = badgeRepository.save(Badge("칭찬뱃지", member))
+
+        // when
+        val result = badgeRepository.findByIdOrNull(expected.id)
+
+        // then
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    @DisplayName("전체 조회시 저장한 모든 데이터가 조회된다")
+    fun findAll() {
+        // given
+        val member = memberRepository.save(Member(OAuth2Details("123", AuthProvider.GOOGLE)))
+
+        val expected: List<Badge> = listOf(
+            Badge("칭찬뱃지1", member),
+            Badge("칭찬뱃지2", member),
+            Badge("칭찬뱃지3", member),
+            Badge("칭찬뱃지4", member)
+        )
+        badgeRepository.saveAll(expected)
+
+        // when
+        val result: List<Badge> = badgeRepository.findAll()
+
+        // then
+        assertThat(result).hasSize(expected.size)
+    }
+}

--- a/src/test/kotlin/sundaystudy/kr/usedcar/module/badge/service/BadgeServiceTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/module/badge/service/BadgeServiceTest.kt
@@ -1,0 +1,48 @@
+package sundaystudy.kr.usedcar.module.badge.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import sundaystudy.kr.usedcar.module.badge.dto.request.RepresentBadgeRequest
+import sundaystudy.kr.usedcar.module.badge.entity.Badge
+import sundaystudy.kr.usedcar.module.badge.repository.BadgeRepository
+import sundaystudy.kr.usedcar.support.application.LoginTest
+
+@DisplayName("Badge 서비스에")
+class BadgeServiceTest: LoginTest() {
+
+    @Autowired private lateinit var badgeService: BadgeService
+    @Autowired private lateinit var badgeRepository: BadgeRepository
+
+    @Test
+    @DisplayName("대표 뱃지 등록시 대표 뱃지로 수정된다.")
+    fun selectRepresentBadge() {
+        // given
+        badgeRepository.save(Badge("칭찬해요", loginUser))
+        val id = badgeRepository.save(Badge("칭찬합니다", loginUser)).id
+
+        // when
+        badgeService.selectRepresentBadge(RepresentBadgeRequest(id))
+
+        // then
+        val result = badgeRepository.findByIdOrNull(id)
+        assertThat(result!!.isRepresent).isTrue()
+    }
+
+    @Test
+    @DisplayName("유저에 대한 모든 뱃지 조회시 저장된 뱃지들이 조회된다")
+    fun getAllBadges() {
+        // given
+        val expected = listOf(Badge("칭찬해요", loginUser), Badge("칭찬합니다", loginUser))
+        badgeRepository.saveAll(expected)
+
+        // when
+        val result = badgeService.getAllBadges(PageRequest.of(0, 20))
+
+        // then
+        assertThat(result).hasSize(expected.size)
+    }
+}

--- a/src/test/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseControllerTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/module/praise/controller/PraiseControllerTest.kt
@@ -39,7 +39,7 @@ class PraiseControllerTest: RestDocsTest() {
         //when
         val perform = mockMvc.perform(
             post("/praises")
-                .content(toRequestBody(PraiseRequest("칭찬합니다~~", UUID.randomUUID(), "친절해요")))
+                .content(toRequestBody(PraiseRequest(UUID.randomUUID(), "친절해요")))
                 .header("Authorization", "Bearer 12asdf21435.asdfgafdsg231f.432t4243cf")
                 .contentType(MediaType.APPLICATION_JSON))
 
@@ -115,7 +115,7 @@ class PraiseControllerTest: RestDocsTest() {
     @DisplayName("칭찬 상세 조회 api가 수행되는가")
     fun getPraiseDetails() {
         //given
-        val expected = PraiseDetailsResponse(UUID.randomUUID(), "친절해요", "친절하게 설명해주셨어요")
+        val expected = PraiseDetailsResponse(UUID.randomUUID(), "친절해요")
         `when`(praiseService.getPraiseDetails(any(UUID::class.java))).thenReturn(expected)
 
         //when
@@ -148,7 +148,7 @@ class PraiseControllerTest: RestDocsTest() {
         //when
         val perform = mockMvc.perform(
             put("/praises")
-                .content(toRequestBody(PraiseUpdateRequest(UUID.randomUUID(), "친절해요", "완전 친절!!")))
+                .content(toRequestBody(PraiseUpdateRequest(UUID.randomUUID(), "친절해요")))
                 .header("Authorization", "Bearer 12asdf21435.asdfgafdsg231f.432t4243cf")
                 .contentType(MediaType.APPLICATION_JSON))
 

--- a/src/test/kotlin/sundaystudy/kr/usedcar/support/application/DatabaseTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/support/application/DatabaseTest.kt
@@ -1,0 +1,12 @@
+package sundaystudy.kr.usedcar.support.application
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@ActiveProfiles("test")
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+annotation class DatabaseTest

--- a/src/test/kotlin/sundaystudy/kr/usedcar/support/application/LoginTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/support/application/LoginTest.kt
@@ -1,0 +1,29 @@
+package sundaystudy.kr.usedcar.support.application
+
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import sundaystudy.kr.usedcar.module.member.entity.AuthProvider
+import sundaystudy.kr.usedcar.module.member.entity.Member
+import sundaystudy.kr.usedcar.module.member.entity.OAuth2Details
+import sundaystudy.kr.usedcar.module.member.repository.MemberRepository
+import sundaystudy.kr.usedcar.module.member.service.AuthService
+
+@DatabaseTest
+abstract class LoginTest {
+
+    @MockBean
+    protected lateinit var authService: AuthService
+
+    @Autowired
+    protected lateinit var memberRepository: MemberRepository
+    protected lateinit var loginUser: Member
+
+    @BeforeEach
+    fun setup() {
+        val member = Member(OAuth2Details("123456789", AuthProvider.KAKAO))
+        loginUser = memberRepository.save(member)
+        `when`(authService.getLoginUser()).thenReturn(loginUser)
+    }
+}

--- a/src/test/kotlin/sundaystudy/kr/usedcar/support/application/LoginTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/support/application/LoginTest.kt
@@ -25,5 +25,6 @@ abstract class LoginTest {
         val member = Member(OAuth2Details("123456789", AuthProvider.KAKAO))
         loginUser = memberRepository.save(member)
         `when`(authService.getLoginUser()).thenReturn(loginUser)
+        `when`(authService.getLoginUserId()).thenReturn(loginUser.id)
     }
 }

--- a/src/test/kotlin/sundaystudy/kr/usedcar/support/infra/EnableJpaTest.kt
+++ b/src/test/kotlin/sundaystudy/kr/usedcar/support/infra/EnableJpaTest.kt
@@ -1,0 +1,14 @@
+package sundaystudy.kr.usedcar.support.infra
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@Transactional
+@ActiveProfiles("test")
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+annotation class EnableJpaTest


### PR DESCRIPTION
## 수행한 태스크
1. service 및 repository 테스트를 위한 설정 클래스, 어노테이션 구성
2. Badge 도메인의 service 와 repository 테스트 코드 작성

## Service, Repository 테스트시 사용할 클래스
### Service 테스트시 LoginTest 상속 받기
  - 다른 어노테이션이나 설정은 필요 없고 바로 테스트 가능
  - LoginTest는 Member 타입의 loginUser를 protected로 가지고 있고 db에 저장된 객체(영속 상태).
  - authService, memberRepository 또한 protected로 존재
  - 서비스 로직에서 authService.getLoginUser() 호출시 loginUser 반환하도록 설정
  - 서비스 로직에서 authService.getLoginUserId() 호출시 loginUser.id 반환하도록 설정
### Repository 테스트시 @EnableJpaTest 어노테이션을 테스트 클래스에 적용
  - 이것도 적용 후 바로 테스트 코드 작성하시면 됩니다.

## 에러 사항
1. MapStruct 의 impl 클래스 생성 안됨
2. UsedCar 도메인의 InsuranceRequest와 이를 활용하는 UsedCarService에서 실행시 에러 발생
3. MatchingController, BookmarkController에 @RequestMapping이 아닌 빈 이름으로 url 경로가 등록됨